### PR TITLE
Feature/versioned cache

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: subhaloscript
-  version: "1.1.8"
+  version: "1.1.9"
 
 source:
   path: .  # Or use `git_url`/`url` if not building from local files

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: subhaloscript
-  version: "1.1.7"
+  version: "1.1.8"
 
 source:
   path: .  # Or use `git_url`/`url` if not building from local files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 dependencies = ["numpy","pandas","scipy","h5py", "scikit-learn", "astropy"]
 name = "subhaloscript"
-version = "1.1.7"
+version = "1.1.8"
 authors = [
   { name="Charles Gannon", email="cgannon@ucmerced.edu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 dependencies = ["numpy","pandas","scipy","h5py", "scikit-learn", "astropy"]
 name = "subhaloscript"
-version = "1.1.8"
+version = "1.1.9"
 authors = [
   { name="Charles Gannon", email="cgannon@ucmerced.edu" },
 ]

--- a/subscript/subhalo_timeseries.py
+++ b/subscript/subhalo_timeseries.py
@@ -3,6 +3,7 @@ import os
 import pickle
 import hashlib
 from pathlib import Path
+from importlib.metadata import version, PackageNotFoundError
 
 import h5py
 import numpy as np
@@ -13,6 +14,21 @@ from subscript.scripts import nfilters as nf
 from subscript.tracking import track_subhalos, track_subhalo
 
 
+def _subscript_version():
+    """Installed subscript (subhaloscript) version string used to stamp caches.
+
+    Reflects the *installed* package metadata, which is the correct notion of
+    "the subscript that produced a cache". For an editable install this is
+    frozen at install time and only refreshes on reinstall. Returns 'unknown'
+    if the package is not installed via metadata, in which case it never matches
+    a stamped version and caches are always regenerated (safe).
+    """
+    try:
+        return version('subhaloscript')
+    except PackageNotFoundError:
+        return 'unknown'
+
+
 def subhalo_timeseries(galacticus_hdf5: h5py.File, tree_index: int, refresh=False, include_isolated=False) -> dict:
     """
     Extract per-subhalo time-series data for all subhalos in a Galacticus tree.
@@ -20,7 +36,9 @@ def subhalo_timeseries(galacticus_hdf5: h5py.File, tree_index: int, refresh=Fals
     Retrieves all subhalo node IDs at the last snapshot of the given tree, runs
     track_subhalos across all snapshots, then filters each subhalo's time-series
     via track_subhalo (removing isolated unless include_isolated is True). Results
-    are cached to disk using pickle.
+    are cached to disk using pickle. Each cache is stamped with the subscript
+    version that produced it and is transparently regenerated when the installed
+    subscript version changes (or when an older, unversioned cache is found).
 
     Parameters
     ----------
@@ -52,7 +70,14 @@ def subhalo_timeseries(galacticus_hdf5: h5py.File, tree_index: int, refresh=Fals
 
     if os.path.exists(cache_path) and not refresh:
         with open(cache_path, 'rb') as f:
-            return pickle.load(f)
+            cached = pickle.load(f)
+        # Reuse only if the cache was produced by the current subscript version.
+        # Older, unversioned caches are raw dicts keyed by int node_id, so the
+        # string-key lookup returns None (no collision) -> treated as stale.
+        if isinstance(cached, dict) and cached.get('subscript_version') == _subscript_version():
+            return cached['result']
+        # stale (version mismatch or old unversioned format): fall through,
+        # recompute, and overwrite cache_path below.
 
     # Get all subhalo node IDs at the last output of this tree
     trees = tabulate_trees(galacticus_hdf5)
@@ -79,6 +104,6 @@ def subhalo_timeseries(galacticus_hdf5: h5py.File, tree_index: int, refresh=Fals
         result[node_id] = {'data': filtered_data, 'zsnaps': filtered_zsnaps}
 
     with open(cache_path, 'wb') as f:
-        pickle.dump(result, f)
+        pickle.dump({'subscript_version': _subscript_version(), 'result': result}, f)
 
     return result

--- a/subscript/tracking.py
+++ b/subscript/tracking.py
@@ -4,6 +4,25 @@ from subscript.tabulatehdf5 import get_galacticus_outputs, tabulate_trees
 from subscript.scripts.nodes import nodedata
 from subscript.defaults import ParamKeys
 
+def _tree_order(galacticus_out, isnap):
+    """Physical ``mergerTreeIndex`` id sitting at each positional tree block of output ``isnap``.
+
+    Galacticus writes the per-output tree blocks in an order that can permute
+    from output to output, so a positional block index does NOT correspond to a
+    fixed physical tree across snapshots. This returns the physical tree id at
+    each block position for a single output, so callers can resolve a positional
+    index to a snapshot-stable physical id.
+    """
+    return np.asarray(galacticus_out["Outputs"][f"Output{int(isnap)}"]["mergerTreeIndex"][:])
+
+def _tree_position(galacticus_out, isnap, phys_tree):
+    """Positional block index of physical tree ``phys_tree`` at output ``isnap``.
+
+    Returns ``None`` if that physical tree has no block at this output.
+    """
+    pos = np.flatnonzero(_tree_order(galacticus_out, isnap) == phys_tree)
+    return int(pos[0]) if pos.size else None
+
 def track_subhalos(galacticus_out, nodeIndices, treeIndex,  param_keys = None):
     """Extract time-series data for specified subhalo nodes across all Galacticus snapshots.
     NOTE: To use this function, galacticus must be run with the nodeOperator indexShift.
@@ -20,7 +39,10 @@ def track_subhalos(galacticus_out, nodeIndices, treeIndex,  param_keys = None):
     nodeIndices : array-like
         Array of node indices for subhalos to track
     treeIndex : int
-        Index of the merger tree to extract data from
+        Positional index of the merger tree in the latest output's tree list.
+        This is resolved once to a physical ``mergerTreeIndex`` id, which is
+        stable across snapshots, and that physical id is used to select the tree
+        block at every output (see Notes).
     param_keys : list of str, optional
         List of parameter keys to extract for each subhalo. If None, extracts all available keys
         from the tree at the first snapshot
@@ -31,8 +53,24 @@ def track_subhalos(galacticus_out, nodeIndices, treeIndex,  param_keys = None):
         Nested dictionary with structure {node_id: {param_key: time_series_array, 'zsnap': redshift_array}}
     zsnaps : ndarray
         Array of redshifts at each snapshot (averaged over host halos)
+
+    Notes
+    -----
+    Nodes are followed by physical tree id, NOT by positional block index.
+    Galacticus can permute the per-output tree block order, and ``nodeIndex`` is
+    only unique *within* a tree (``indexShift`` keeps an index stable across
+    outputs but the same integer is reused across trees). Selecting a fixed
+    positional block index therefore follows different physical trees across
+    outputs and, via the shared ``nodeIndex``, splices unrelated halos into one
+    time series. Resolving ``treeIndex`` to a physical ``mergerTreeIndex`` id and
+    selecting by that id at every output removes the splice.
     """
     snaps = np.flip(np.asarray(get_galacticus_outputs(galacticus_out)))
+
+    # Resolve the caller's positional treeIndex (into the latest output's tree
+    # list) to a physical mergerTreeIndex id, then select by that id at every
+    # output so a permuting block order can't swap in a different physical tree.
+    phys_tree = int(_tree_order(galacticus_out, snaps[0])[treeIndex])
 
     param_keys = param_keys if param_keys is not None else [_key for _key in tabulate_trees(galacticus_out, snaps[0])[treeIndex].keys()]
 
@@ -41,8 +79,12 @@ def track_subhalos(galacticus_out, nodeIndices, treeIndex,  param_keys = None):
     zsnaps = np.zeros(len(snaps))
 
     for j, isnap in enumerate(snaps):
-        snap = tabulate_trees(galacticus_out, isnap)[treeIndex]  
-        nd = nodedata(snap, key=param_keys)    
+        pos = _tree_position(galacticus_out, isnap, phys_tree)
+        if pos is None:
+            continue  # physical tree absent at this output; leave zeros (filtered downstream)
+
+        snap = tabulate_trees(galacticus_out, isnap)[pos]
+        nd = nodedata(snap, key=param_keys)
 
         ids = nodedata(snap, 'nodeIndex')
 
@@ -50,10 +92,10 @@ def track_subhalos(galacticus_out, nodeIndices, treeIndex,  param_keys = None):
 
         for n, id in enumerate(ids):
             if id not in nodeIndices:
-                continue 
+                continue
             for i, key in enumerate(param_keys):
                 subhalo_data[id][key][j] = nd[i][n]
-                        
+
     return subhalo_data, zsnaps
  
 def track_subhalo(subhalos_over_time, zsnaps, nodeindex, param_keys, include_isolated=False):

--- a/tests/test_subhalo_timeseries_cache.py
+++ b/tests/test_subhalo_timeseries_cache.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+'''Tests for the version-stamped subhalo_timeseries disk cache.
+
+Each cache pickle is wrapped as {'subscript_version': <ver>, 'result': <dict>}
+and is only reused when the stamped version matches the currently installed
+subscript version; otherwise (version mismatch, or an older unversioned raw-dict
+cache) it is transparently regenerated and overwritten. refresh=True always
+recomputes.
+
+Uses a minimal synthetic Galacticus file built in a tmp dir (same pattern as
+tests/test_tracking.py) so the cache lands in tmp_path and no large fixture is
+needed.
+'''
+import pickle
+
+import numpy as np
+import h5py
+import pytest
+
+from subscript.subhalo_timeseries import subhalo_timeseries, _subscript_version
+from subscript.defaults import ParamKeys
+
+RKEY = ParamKeys.dark_matter_profile_dmo_radius_velocity_max
+SAT_INDEX = 100
+SAT2_INDEX = 200
+SAT_RMAX = {1: 10.0, 2: 999.0}
+NODES_PER_TREE = 3   # host + 2 satellites (>1 subhalo so node_ids stays an array)
+
+
+def _write_output(outputs_grp, out_num, tree_order, z):
+    # per tree block: [host, satellite 100, satellite 200]
+    idx, iso, bound, rmax, zli = [], [], [], [], []
+    for tid in tree_order:
+        idx += [tid, SAT_INDEX, SAT2_INDEX]; iso += [1, 0, 0]
+        bound += [0.0, 1.0e9, 5.0e8]; rmax += [50.0, SAT_RMAX[tid], 20.0]
+        zli += [z, z, z]
+    g = outputs_grp.create_group(f'Output{out_num}')
+    g.create_dataset('mergerTreeIndex', data=np.asarray(tree_order, np.int64))
+    g.create_dataset('mergerTreeCount', data=np.full(len(tree_order), NODES_PER_TREE, np.int64))
+    nd = g.create_group('nodeData')
+    nd.create_dataset('nodeIndex', data=np.asarray(idx, np.int64))
+    nd.create_dataset(ParamKeys.is_isolated, data=np.asarray(iso, np.int64))
+    nd.create_dataset(ParamKeys.mass_bound, data=np.asarray(bound, np.float64))
+    nd.create_dataset(RKEY, data=np.asarray(rmax, np.float64))
+    nd.create_dataset(ParamKeys.z_lastisolated, data=np.asarray(zli, np.float64))
+
+
+def _make_file(path, orders):
+    with h5py.File(path, 'w') as f:
+        outs = f.create_group('Outputs')
+        n = len(orders)
+        for k, (out_num, order) in enumerate(sorted(orders.items())):
+            _write_output(outs, out_num, order, z=float(n - 1 - k))
+    return path
+
+
+@pytest.fixture
+def gfile(tmp_path):
+    return _make_file(tmp_path / 'g.hdf5', {1: [1, 2], 2: [1, 2]})
+
+
+def _only_cache(tmp_path):
+    pkls = list(tmp_path.glob('*.pkl'))
+    assert len(pkls) == 1, pkls
+    return pkls[0]
+
+
+def _load(path):
+    with open(path, 'rb') as f:
+        return pickle.load(f)
+
+
+def _dump(path, obj):
+    with open(path, 'wb') as f:
+        pickle.dump(obj, f)
+
+
+def test_cache_written_with_version(gfile, tmp_path):
+    with h5py.File(gfile, 'r') as f:
+        res = subhalo_timeseries(f, 0)
+    cached = _load(_only_cache(tmp_path))
+    assert isinstance(cached, dict)
+    assert cached['subscript_version'] == _subscript_version()
+    assert isinstance(cached['result'], dict)
+    assert set(cached['result']) == set(res)       # same node ids
+    assert SAT_INDEX in res
+
+
+def test_matching_version_is_reused(gfile, tmp_path):
+    with h5py.File(gfile, 'r') as f:
+        subhalo_timeseries(f, 0)                    # create cache
+        cache = _only_cache(tmp_path)
+        obj = _load(cache)
+        obj['result'] = {'SENTINEL': 123}          # keep current version
+        _dump(cache, obj)
+        res = subhalo_timeseries(f, 0)             # should be a cache hit
+    assert res == {'SENTINEL': 123}
+
+
+def test_version_mismatch_regenerates(gfile, tmp_path):
+    with h5py.File(gfile, 'r') as f:
+        subhalo_timeseries(f, 0)
+        cache = _only_cache(tmp_path)
+        _dump(cache, {'subscript_version': '0.0.0-stale', 'result': {'SENTINEL': 1}})
+        res = subhalo_timeseries(f, 0)             # stale -> recompute + overwrite
+    assert 'SENTINEL' not in res
+    assert SAT_INDEX in res
+    assert _load(cache)['subscript_version'] == _subscript_version()
+
+
+def test_old_unversioned_format_regenerates(gfile, tmp_path):
+    with h5py.File(gfile, 'r') as f:
+        subhalo_timeseries(f, 0)
+        cache = _only_cache(tmp_path)
+        _dump(cache, {999: 'sentinel'})            # legacy raw-dict cache
+        res = subhalo_timeseries(f, 0)
+    assert res.get(999) != 'sentinel'
+    reloaded = _load(cache)
+    assert 'subscript_version' in reloaded
+    assert reloaded['subscript_version'] == _subscript_version()
+    assert SAT_INDEX in reloaded['result']
+
+
+def test_refresh_recomputes_even_on_match(gfile, tmp_path):
+    with h5py.File(gfile, 'r') as f:
+        subhalo_timeseries(f, 0)
+        cache = _only_cache(tmp_path)
+        _dump(cache, {'subscript_version': _subscript_version(), 'result': {'SENTINEL': 1}})
+        res = subhalo_timeseries(f, 0, refresh=True)
+    assert 'SENTINEL' not in res
+    assert SAT_INDEX in res

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+'''Regression tests for subscript.tracking.track_subhalos.
+
+Guards against the cross-tree nodeIndex splice: track_subhalos must follow a
+subhalo by its PHYSICAL merger tree, not by a positional block index. Galacticus
+may permute the per-output tree block order, and nodeIndex is only unique within
+a tree (indexShift keeps an index stable across outputs but the same integer is
+reused across trees). A positional-index tracker therefore follows different
+physical trees across outputs and splices unrelated halos that share a nodeIndex.
+
+These tests build a minimal synthetic Galacticus file in a tmp dir (so they do
+not depend on the large real fixture) with:
+  - two physical trees (ids 1 and 2),
+  - a satellite nodeIndex 100 present in BOTH trees with a DISTINCT R_max
+    (10.0 in tree 1, 999.0 in tree 2),
+  - a per-output tree block order that PERMUTES (so positional index 0 is
+    tree 1 at some outputs and tree 2 at others).
+
+Tracking node 100 of physical tree 1 must return R_max == 10.0 at every output;
+a positional tracker would splice in the 999.0 from tree 2 at the permuted
+output.
+'''
+import numpy as np
+import h5py
+import pytest
+
+from subscript.tracking import track_subhalos, _tree_position
+from subscript.defaults import ParamKeys
+
+RKEY = ParamKeys.dark_matter_profile_dmo_radius_velocity_max
+# track_subhalos indexes nodedata output as nd[key_i][node_n]; nodedata collapses
+# a single-key list to 1-D, so use >= 2 keys (as every real caller does).
+PARAM_KEYS = [RKEY, ParamKeys.mass_bound]
+HOST_RMAX = 50.0
+SAT_INDEX = 100
+SAT_RMAX = {1: 10.0, 2: 999.0}   # per physical tree
+
+
+def _write_output(outputs_grp, out_num, tree_order, z):
+    '''Write one Output{out_num} group. tree_order is the physical tree id per
+    positional block; each tree contributes [host, satellite]. Node arrays are
+    concatenated in block order, matching Galacticus' layout.'''
+    idx, iso, bound, rmax, zli = [], [], [], [], []
+    for tid in tree_order:
+        # host (isolated)
+        idx.append(tid); iso.append(1); bound.append(0.0)
+        rmax.append(HOST_RMAX); zli.append(z)
+        # satellite, shared nodeIndex across trees, tree-distinct R_max
+        idx.append(SAT_INDEX); iso.append(0); bound.append(1.0e9)
+        rmax.append(SAT_RMAX[tid]); zli.append(z)
+
+    g = outputs_grp.create_group(f'Output{out_num}')
+    g.create_dataset('mergerTreeIndex', data=np.asarray(tree_order, dtype=np.int64))
+    g.create_dataset('mergerTreeCount', data=np.full(len(tree_order), 2, dtype=np.int64))
+    nd = g.create_group('nodeData')
+    nd.create_dataset('nodeIndex', data=np.asarray(idx, dtype=np.int64))
+    nd.create_dataset(ParamKeys.is_isolated, data=np.asarray(iso, dtype=np.int64))
+    nd.create_dataset(ParamKeys.mass_bound, data=np.asarray(bound, dtype=np.float64))
+    nd.create_dataset(RKEY, data=np.asarray(rmax, dtype=np.float64))
+    nd.create_dataset(ParamKeys.z_lastisolated, data=np.asarray(zli, dtype=np.float64))
+
+
+def _make_file(path, orders):
+    '''orders: dict {output_number: [physical tree ids in block order]}.
+    Output numbers increase with cosmic time (higher = later = lower z).'''
+    with h5py.File(path, 'w') as f:
+        outs = f.create_group('Outputs')
+        n = len(orders)
+        for k, (out_num, order) in enumerate(sorted(orders.items())):
+            _write_output(outs, out_num, order, z=float(n - 1 - k))
+
+
+@pytest.fixture
+def permuted_file(tmp_path):
+    '''Latest output (3) has order [1,2]; the middle output (2) is PERMUTED to
+    [2,1]; the earliest (1) is [1,2] again.'''
+    p = tmp_path / 'permuted.hdf5'
+    _make_file(p, {1: [1, 2], 2: [2, 1], 3: [1, 2]})
+    return p
+
+
+def test_tree_position_follows_physical_tree(permuted_file):
+    with h5py.File(permuted_file, 'r') as f:
+        # latest output 3: order [1,2]
+        assert _tree_position(f, 3, 1) == 0
+        assert _tree_position(f, 3, 2) == 1
+        # permuted output 2: order [2,1] -> physical tree 1 is now block 1
+        assert _tree_position(f, 2, 1) == 1
+        assert _tree_position(f, 2, 2) == 0
+        # absent tree -> None
+        assert _tree_position(f, 2, 99) is None
+
+
+def test_no_cross_tree_splice_permuted_order(permuted_file):
+    '''Track node 100 of physical tree 1 (positional 0 at the latest output).
+    Every recorded R_max must be tree 1's 10.0 -- never tree 2's 999.0.'''
+    with h5py.File(permuted_file, 'r') as f:
+        data, zsnaps = track_subhalos(f, nodeIndices=np.array([SAT_INDEX]),
+                                      treeIndex=0, param_keys=PARAM_KEYS)
+    rmax = data[SAT_INDEX][RKEY]
+    assert rmax.shape == (3,)
+    assert np.all(rmax == SAT_RMAX[1]), rmax
+    assert not np.any(rmax == SAT_RMAX[2]), 'tree-2 value spliced in (cross-tree splice)'
+
+
+def test_tracks_correct_tree_when_selected(permuted_file):
+    '''Selecting the other physical tree (positional 1 at the latest output =
+    tree 2) must return tree 2's values, confirming per-tree selection is right
+    in both directions.'''
+    with h5py.File(permuted_file, 'r') as f:
+        data, _ = track_subhalos(f, nodeIndices=np.array([SAT_INDEX]),
+                                 treeIndex=1, param_keys=PARAM_KEYS)
+    rmax = data[SAT_INDEX][RKEY]
+    assert np.all(rmax == SAT_RMAX[2]), rmax
+
+
+def test_stable_order_is_a_noop(tmp_path):
+    '''With a non-permuting order, physical-tree selection reduces to the plain
+    positional selection: tree 1 -> 10.0, tree 2 -> 999.0 at every output.'''
+    p = tmp_path / 'stable.hdf5'
+    _make_file(p, {1: [1, 2], 2: [1, 2], 3: [1, 2]})
+    with h5py.File(p, 'r') as f:
+        d0, _ = track_subhalos(f, np.array([SAT_INDEX]), treeIndex=0, param_keys=PARAM_KEYS)
+        d1, _ = track_subhalos(f, np.array([SAT_INDEX]), treeIndex=1, param_keys=PARAM_KEYS)
+    assert np.all(d0[SAT_INDEX][RKEY] == SAT_RMAX[1])
+    assert np.all(d1[SAT_INDEX][RKEY] == SAT_RMAX[2])


### PR DESCRIPTION
Fix: bug with subhalo_timeseries — galacticus trees can swap order in different snapshots, added code to handle these permutations. 
Feat: Add code to regenerate cache if a different version of subscript was used to gernerate the cache